### PR TITLE
Support dfifferent test configurations (integrationTest, componentTest,

### DIFF
--- a/lua/neotest-gradle/hooks/collect_results.lua
+++ b/lua/neotest-gradle/hooks/collect_results.lua
@@ -1,5 +1,6 @@
 local lib = require('neotest.lib')
 local xml = require('neotest.lib.xml')
+local logger = require("neotest.logging")
 local get_package_name = require('neotest-gradle.hooks.shared_utilities').get_package_name
 
 local XML_FILE_SUFFIX = '.xml'
@@ -38,6 +39,22 @@ end
 --- result from the JUnit report XML. Therefore it parses the location from the
 --- node attributes and compares it with the position information in the tree.
 ---
+--- Position: [id] [name]
+--- Position: /.../.../.../ordermanagement/files/rest/FileResponseMapperTest.java FileResponseMapperTest.java
+--- Function name: toFileResponseTest
+--- Package and class: com.jysk.ordermanagement.files.rest.FileResponseMapperTest
+--- Position: com.jysk.ordermanagement.files.rest.FileResponseMapperTest file response mapper test
+--- Function name: toFileResponseTest
+--- Package and class: com.jysk.ordermanagement.files.rest.FileResponseMapperTest
+--- Position: com.jysk.ordermanagement.files.rest.FileResponseMapperTest.toFileResponseTest to file response test
+--- Function name: toFileResponseTest
+--- Package and class: com.jysk.ordermanagement.files.rest.FileResponseMapperTest
+--- Position: com.jysk.ordermanagement.files.rest.FileResponseMapperTest.mapFileIdTest map file id test
+--- Function name: toFileResponseTest
+--- Package and class: com.jysk.ordermanagement.files.rest.FileResponseMapperTest
+--- Position: com.jysk.ordermanagement.files.rest.FileResponseMapperTest.mapFileContentTypeTest map file content type test
+--- Function name: toFileResponseTest
+--- Package and class: com.jysk.ordermanagement.files.rest.FileResponseMapperTest
 --- @param tree table - see neotest.Tree
 --- @param test_case_node table - XML node of test case result
 --- @return table | nil - see neotest.Position
@@ -46,7 +63,7 @@ local function find_position_for_test_case(tree, test_case_node)
   local package_and_class = (test_case_node._attr.classname:gsub('%$', '%.'))
 
   for _, position in tree:iter() do
-    if position.name == function_name and vim.startswith(position.id, package_and_class) then
+    if vim.startswith(position.id, package_and_class) and vim.endswith(position.id, function_name) then
       return position
     end
   end
@@ -88,6 +105,7 @@ end
 --- It also tries to determine why and where a test possibly failed for
 --- additional Neotest features like diagnostics.
 ---
+--- @async
 --- @param build_specfication table - see neotest.RunSpec
 --- @param tree table - see neotest.Tree
 --- @return table<string, table> - see neotest.Result

--- a/lua/neotest-gradle/hooks/discover_positions/init.lua
+++ b/lua/neotest-gradle/hooks/discover_positions/init.lua
@@ -1,3 +1,4 @@
+local async = require("neotest.async")
 local lib = require('neotest.lib')
 local filetype = require('plenary.filetype')
 local position_queries = require('neotest-gradle.position_queries')
@@ -12,6 +13,7 @@ local position_queries = require('neotest-gradle.position_queries')
 --- Referred context functions help to provide good readable test names for UI
 --- and construct test identifiers based on Java paths used during execution.
 ---
+--- @async
 --- @param path string - absolute file path
 --- @return nil | table | table[] - see neotest.Tree
 return function(path)

--- a/lua/neotest-gradle/hooks/test_configuration_resolver.lua
+++ b/lua/neotest-gradle/hooks/test_configuration_resolver.lua
@@ -1,0 +1,43 @@
+local logger = require("neotest.logging")
+
+-- Function: extract_test_dir
+-- Description: Extracts the directory name located between 'src' and 'java' in a given file path.
+-- Parameters:
+--   path (string): The full file path.
+--   project_dir (string): The project directory path.
+-- Returns:
+--   test_dir (string) or nil: The name of the test directory or nil if not found.
+local function extract_test_directory(path, project_directory)
+    logger.info("Extracting test directory from path: " .. path .. " and project directory: " .. project_directory)
+
+    -- Remove the projectDirectory from the path
+    local relative_path = path:gsub('^' .. vim.pesc(project_directory), '')
+
+    -- Remove any leading slash from the relative path
+    relative_path = relative_path:gsub('^/', '')
+
+    -- Use pattern matching to extract the name between 'src/' and '/java/'
+    local something = relative_path:match('src/([^/]+)/java/')
+    logger.info("Extracted test directory: " .. something)
+    return something
+end
+
+local function get_test_configuration(arguments, test_directory)
+    local test_configuration = nil
+    if (arguments.test_configuration ~= nil) then
+        test_configuration = arguments.test_configuration
+    else
+        if (test_directory ~= nil) then
+            test_configuration = test_directory
+        else
+            test_configuration = 'test'
+        end
+    end
+    logger.info("Using test configuration: " .. test_configuration)
+    return test_configuration
+end
+
+return {
+    extract_test_directory = extract_test_directory,
+    get_test_configuration = get_test_configuration
+}


### PR DESCRIPTION
test) + other small improvements.

Motivation:
I want to be able to run different test configurations in different
  scenarios. In my project we run test configuration but also
  componentTest and integrationTest. In addiotion componentTest places
  test reports in a different directory than test and integrationTest
  (adjusted also in the gradle command).